### PR TITLE
Feat/integrate sidebar category and products list page with api endpoints

### DIFF
--- a/frontend/src/app/(customer)/(about)/product/page.jsx
+++ b/frontend/src/app/(customer)/(about)/product/page.jsx
@@ -1,175 +1,159 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Card, Row, Col, Spin, Empty, Pagination, Select } from 'antd';
 import { ShoppingCartOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 
 export default function ProductsPage() {
-  const [products, setProducts] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [currentPage, setCurrentPage] = useState(0);
-  const [totalItems, setTotalItems] = useState(0);
-  const [sortOrder, setSortOrder] = useState('default');
-  const pageSize = 10;
+    const router = useRouter();
+    const [products, setProducts] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [currentPage, setCurrentPage] = useState(0);
+    const [totalItems, setTotalItems] = useState(0);
+    const [sortOrder, setSortOrder] = useState('default');
+    const pageSize = 10;
 
   const formatPrice = (price) => {
     if (!price) return 'N/A';
     return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '.');
   };
 
-  useEffect(() => {
-    fetchProducts();
-  }, [currentPage, sortOrder]);
+    const calculateOriginalPrice = (currentPrice, discountPercent) => {
+        if (!discountPercent || discountPercent === 0) return currentPrice;
+        return Math.round(currentPrice / (1 - discountPercent / 100));
+    };
 
-  const fetchProducts = async () => {
-    setLoading(true);
-    try {
-      const sortParam = sortOrder !== 'default' ? `&sort=${sortOrder}` : '';
-      // Fetch products with aggregated data
-      const productsResponse = await fetch(
-        `http://localhost:3000/products?page=${currentPage}&size=${pageSize}${sortParam}`
-      );
-      const productsData = await productsResponse.json();
-      setTotalItems(productsData.totalItems || 0);
+    useEffect(() => {
+        fetchProducts();
+    }, [currentPage, sortOrder]);
 
-      // Fetch all brands at once
-      const brandsResponse = await fetch('http://localhost:3000/brands');
-      const brandsData = await brandsResponse.json();
-      const brandsMap = new Map(brandsData.map((brand) => [brand.id, brand]));
-
-      // Combine the data
-      const productsWithDetails = productsData.items.map((product) => ({
-        ...product,
-        brand: brandsMap.get(product.brandId) || null,
-      }));
-
-      setProducts(productsWithDetails);
-    } catch (error) {
-      console.error('Error fetching products:', error);
-      setProducts([]);
-    }
-    setLoading(false);
-  };
+    const fetchProducts = async () => {
+        setLoading(true);
+        try {
+            const sortParam = sortOrder !== 'default' ? `&sort=${sortOrder}` : '';
+            const productsResponse = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/products/search?page=${currentPage}&size=${pageSize}${sortParam}`);
+            const productsData = await productsResponse.json();
+            setTotalItems(productsData.totalItems || 0);
+            setProducts(productsData.items || []);
+        } catch (error) {
+            console.error('Error fetching products:', error);
+            setProducts([]);
+        }
+        setLoading(false);
+    };
 
   const handlePageChange = (page) => {
     setCurrentPage(page - 1);
   };
 
-  const handleSortChange = (value) => {
-    // Convert frontend sort value to backend format
-    let sortValue;
-    switch (value) {
-      case 'price_asc':
-        sortValue = 'price:asc';
-        break;
-      case 'price_desc':
-        sortValue = 'price:desc';
-        break;
-      default:
-        sortValue = undefined;
-    }
-    setSortOrder(sortValue);
-    setCurrentPage(0); // Reset to first page when sorting changes
-  };
+    const handleSortChange = (value) => {
+        let sortValue;
+        switch (value) {
+            case 'price_asc':
+                sortValue = 'price:asc';
+                break;
+            case 'price_desc':
+                sortValue = 'price:desc';
+                break;
+            default:
+                sortValue = 'default';
+        }
+        setSortOrder(sortValue);
+        setCurrentPage(0);
+    };
 
-  return (
-    // <CustomerLayout>
-    <div className="container mx-auto px-4 pb-4">
-      <div className="mb-4 flex justify-end">
-        <Select
-          defaultValue="default"
-          style={{ width: 200 }}
-          onChange={handleSortChange}
-          options={[
-            { value: 'default', label: 'Mặc định' },
-            { value: 'price_asc', label: 'Giá: Thấp đến cao' },
-            { value: 'price_desc', label: 'Giá: Cao đến thấp' },
-          ]}
-        />
-      </div>
-      {loading ? (
-        <div className="flex justify-center items-center h-64">
-          <Spin size="large" />
-        </div>
-      ) : products.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-64">
-          <Empty
-            image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description="No products available at the moment"
-          />
-        </div>
-      ) : (
-        <>
-          <Row gutter={[16, 16]}>
-            {products.map((product) => (
-              <Col xs={24} sm={12} md={8} lg={6} key={product.id}>
-                <Link
-                  href={`product/detail?id=${product?.id}&&name=${product?.name}`}
-                >
-                  <Card
-                    hoverable
-                    className="transition-all duration-300 hover:shadow-lg hover:scale-[1.02]"
-                    cover={
-                      <div className="overflow-hidden">
-                        <img
-                          alt={product.name}
-                          src={
-                            product.image_url ||
-                            'https://th.bing.com/th/id/OIP.Msemb0oPJ1dkR00ANAh6iwHaHa?rs=1&pid=ImgDetMain'
-                          }
-                          //via.placeholder.com/300'}
-                          className="w-full h-full object-cover transition-transform duration-300 hover:scale-110"
-                        />
-                      </div>
-                    }
-                  >
-                    <Card.Meta
-                      title={
-                        <div className="flex flex-row space-x-2 items-center">
-                          <div
-                            className="text-lg font-semibold transition-colors duration-300 hover:text-[#ff69b4]"
-                            style={{ color: '#ff85c1' }}
-                          >
-                            {formatPrice(product.lowestPrice)} ₫
-                          </div>
-                          <div className="text-sm line-through">202.000 ₫</div>
-                        </div>
-                      }
-                      description={
-                        <div className="space-y-2">
-                          <p
-                            className="font-bold transition-colors duration-300 hover:text-[#ff69b4]"
-                            style={{ color: '#ff85c1' }}
-                          >
-                            {product.brand?.name || 'Unknown Brand'}
-                          </p>
-                          <p className="text-gray-600 transition-colors duration-300 hover:text-[#ff69b4]">
-                            {product.name || 'Unknown Product Name'}
-                          </p>
-                          <div className="flex items-center text-gray-500">
-                            <ShoppingCartOutlined className="mr-2" />
-                            <span>{product.totalQuantity || 0}</span>
-                          </div>
-                        </div>
-                      }
+    const handleProductClick = (productId) => {
+        router.push(`/product/detail?id=${productId}`);
+    };
+
+    return (
+        <div className="container mx-auto px-4 pb-4">
+            <div className="mb-4 flex justify-end">
+                <Select
+                    defaultValue="default"
+                    style={{ width: 200 }}
+                    onChange={handleSortChange}
+                    options={[
+                        { value: 'default', label: 'Mặc định' },
+                        { value: 'price_asc', label: 'Giá: Thấp đến cao' },
+                        { value: 'price_desc', label: 'Giá: Cao đến thấp' },
+                    ]}
+                />
+            </div>
+            {loading ? (
+                <div className="flex justify-center items-center h-64">
+                    <Spin size="large" />
+                </div>
+            ) : products.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-64">
+                    <Empty
+                        image={Empty.PRESENTED_IMAGE_SIMPLE}
+                        description="No products available at the moment"
                     />
-                  </Card>
-                </Link>
-              </Col>
-            ))}
-          </Row>
-          <div className="flex justify-center mt-8">
-            <Pagination
-              current={currentPage + 1}
-              total={totalItems}
-              pageSize={pageSize}
-              onChange={handlePageChange}
-              showSizeChanger={false}
-            />
-          </div>
-        </>
-      )}
-    </div>
-    // </CustomerLayout>
-  );
+                </div>
+            ) : (
+                <>
+                    <Row gutter={[16, 16]}>
+                        {products.map((product) => (
+                            <Col xs={24} sm={12} md={8} lg={6} key={product.id}>
+                                <Card
+                                    hoverable
+                                    className="transition-all duration-300 hover:shadow-lg hover:scale-[1.02]"
+                                    onClick={() => handleProductClick(product.id)}
+                                    cover={
+                                        <div className="overflow-hidden">
+                                            <img
+                                                alt={product.name}
+                                                src={product.lowestInstance?.productImgs?.[0]?.link || 'https://th.bing.com/th/id/OIP.Msemb0oPJ1dkR00ANAh6iwHaHa?rs=1&pid=ImgDetMain'}
+                                                className="w-full h-full object-cover transition-transform duration-300 hover:scale-110"
+                                            />
+                                        </div>
+                                    }
+                                >
+                                    <Card.Meta
+                                        title={
+                                            <div className="flex flex-row space-x-2 items-center">
+                                                <div className="text-lg font-semibold transition-colors duration-300 hover:text-[#ff69b4]" style={{ color: '#ff85c1' }}>
+                                                    {formatPrice(product.lowestPrice)} ₫
+                                                </div>
+                                                {product.lowestInstance?.discountPercent > 0 && (
+                                                    <div className="text-sm line-through text-gray-400">
+                                                        {formatPrice(calculateOriginalPrice(product.lowestPrice, product.lowestInstance.discountPercent))} ₫
+                                                    </div>
+                                                )}
+                                            </div>
+                                        }
+                                        description={
+                                            <div className="space-y-2">
+                                                <p className="font-bold transition-colors duration-300 hover:text-[#ff69b4]" style={{ color: '#ff85c1' }}>
+                                                    {product.brand?.name || 'Unknown Brand'}
+                                                </p>
+                                                <p className="text-gray-600 transition-colors duration-300 hover:text-[#ff69b4]">
+                                                    {product.name || 'Unknown Product Name'}
+                                                </p>
+                                                <div className="flex items-center text-gray-500">
+                                                    <ShoppingCartOutlined className="mr-2" />
+                                                    <span>{product.productInstances?.reduce((total, instance) => total + (instance.quantity || 0), 0) || 0}</span>
+                                                </div>
+                                            </div>
+                                        }
+                                    />
+                                </Card>
+                            </Col>
+                        ))}
+                    </Row>
+                    <div className="flex justify-center mt-8">
+                        <Pagination
+                            current={currentPage + 1}
+                            total={totalItems}
+                            pageSize={pageSize}
+                            onChange={handlePageChange}
+                            showSizeChanger={false}
+                        />
+                    </div>
+                </>
+            )}
+        </div>
+    );
 }

--- a/frontend/src/app/(customer)/components/category_sidebar.jsx
+++ b/frontend/src/app/(customer)/components/category_sidebar.jsx
@@ -2,20 +2,36 @@
 import { tokenCustomer } from '@/context/config_provider';
 import { Menu, InputNumber, Button } from 'antd';
 import Link from 'next/link';
-import { useState } from 'react';
-
-const categories = [
-  { key: 'vaseline', label: 'Vaseline', path: '/category/vaseline' },
-  { key: 'lip-ice', label: 'LipIce', path: '/category/lip-ice' },
-  { key: 'silky-girl', label: 'SilkyGirl', path: '/category/silky-girl' },
-  { key: 'nivea', label: 'Nivea', path: '/category/nivea' },
-  { key: 'cocoon', label: 'Cocoon', path: '/category/cocoon' },
-  { key: 'bare-soul', label: 'BareSoul', path: '/category/bare-soul' },
-];
+import { useState, useEffect } from 'react';
 
 export default function CategorySidebar() {
+  const [categories, setCategories] = useState([]);
   const [minPrice, setMinPrice] = useState(0);
   const [maxPrice, setMaxPrice] = useState(1000);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/categories`);
+        if (response.ok) {
+          const categoriesData = await response.json();
+          const transformed = categoriesData
+            .filter(category => category.status)
+            .map(category => ({
+              key: category.id,
+              label: category.name,
+              path: `/category/${category.id}`
+            }));
+          setCategories(transformed);
+        } else {
+          setCategories([]);
+        }
+      } catch {
+        setCategories([]);
+      }
+    };
+    fetchCategories();
+  }, []);
 
   const handleMinPriceChange = (value) => {
     setMinPrice(value);
@@ -46,11 +62,9 @@ export default function CategorySidebar() {
           label: (
             <a
               href={category.path}
-              style={{
-                color: 'black',
-              }}
-              onMouseEnter={(e) => (e.target.style.color = tokenCustomer.colorLinkHover)}
-              onMouseLeave={(e) => (e.target.style.color = 'black')}
+              style={{ color: 'black' }}
+              onMouseEnter={e => (e.target.style.color = tokenCustomer.colorLinkHover)}
+              onMouseLeave={e => (e.target.style.color = 'black')}
             >
               {category.label}
             </a>


### PR DESCRIPTION
these are the two changes of this PR
- integrate the sidebar categories list with API /categories
![image](https://github.com/user-attachments/assets/7859b2af-f88c-4401-94c3-eecea7891f0e)

- integrate the products list with API /product/search and handle clicking on an item in the list navigate to the corresponding detail page
![image](https://github.com/user-attachments/assets/1a9d4b22-cf8b-4824-982e-0e310650d8cd)
