### PR TITLE
Feat/integrate sidebar category filer and header search with api endpoints

### DIFF
--- a/frontend/src/app/(customer)/(about)/product/page.jsx
+++ b/frontend/src/app/(customer)/(about)/product/page.jsx
@@ -1,17 +1,19 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { Card, Row, Col, Spin, Empty, Pagination, Select } from 'antd';
 import { ShoppingCartOutlined } from '@ant-design/icons';
 import Link from 'next/link';
 
 export default function ProductsPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
   const [totalItems, setTotalItems] = useState(0);
   const [sortOrder, setSortOrder] = useState('default');
+  const [categoryId, setCategoryId] = useState(null);
   const pageSize = 10;
 
   const formatPrice = (price) => {
@@ -25,15 +27,27 @@ export default function ProductsPage() {
   };
 
   useEffect(() => {
+    // Lấy categoryId từ query param nếu có
+    const catId = searchParams.get('filter')?.split(':')[2] || null;
+    setCategoryId(catId);
+  }, [searchParams]);
+
+  useEffect(() => {
     fetchProducts();
-  }, [currentPage, sortOrder]);
+  }, [currentPage, sortOrder, categoryId]);
 
   const fetchProducts = async () => {
     setLoading(true);
     try {
       const sortParam = sortOrder !== 'default' ? `&sort=${sortOrder}` : '';
+      let filterParam = '';
+      if (categoryId) {
+        filterParam = `&filter=categoryId:eq:${categoryId}`;
+      } else if (searchParams.get('filter')) {
+        filterParam = `&filter=${searchParams.get('filter')}`;
+      }
       const productsResponse = await fetch(
-        `${process.env.NEXT_PUBLIC_BACKEND_URL}/products/search?page=${currentPage}&size=${pageSize}${sortParam}`
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/products/search?page=${currentPage}&size=${pageSize}${sortParam}${filterParam}`
       );
       const productsData = await productsResponse.json();
       setTotalItems(productsData.totalItems || 0);

--- a/frontend/src/app/(customer)/(about)/product/page.jsx
+++ b/frontend/src/app/(customer)/(about)/product/page.jsx
@@ -32,9 +32,12 @@ export default function ProductsPage() {
     setCategoryId(catId);
   }, [searchParams]);
 
+  // Add: get search param from query
+  const searchText = searchParams.get('search') || '';
+
   useEffect(() => {
     fetchProducts();
-  }, [currentPage, sortOrder, categoryId]);
+  }, [currentPage, sortOrder, categoryId, searchText]);
 
   const fetchProducts = async () => {
     setLoading(true);
@@ -46,8 +49,13 @@ export default function ProductsPage() {
       } else if (searchParams.get('filter')) {
         filterParam = `&filter=${searchParams.get('filter')}`;
       }
+      // Add: search filter
+      let searchFilter = '';
+      if (searchText) {
+        searchFilter = `&filter=name:like:${encodeURIComponent(searchText)}`;
+      }
       const productsResponse = await fetch(
-        `${process.env.NEXT_PUBLIC_BACKEND_URL}/products/search?page=${currentPage}&size=${pageSize}${sortParam}${filterParam}`
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/products/search?page=${currentPage}&size=${pageSize}${sortParam}${filterParam}${searchFilter}`
       );
       const productsData = await productsResponse.json();
       setTotalItems(productsData.totalItems || 0);

--- a/frontend/src/app/(customer)/components/category_sidebar.jsx
+++ b/frontend/src/app/(customer)/components/category_sidebar.jsx
@@ -3,11 +3,17 @@ import { tokenCustomer } from '@/context/config_provider';
 import { Menu, InputNumber, Button } from 'antd';
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 export default function CategorySidebar() {
   const [categories, setCategories] = useState([]);
   const [minPrice, setMinPrice] = useState(0);
   const [maxPrice, setMaxPrice] = useState(1000);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [activeCategory, setActiveCategory] = useState(null);
 
   useEffect(() => {
     const fetchCategories = async () => {
@@ -33,6 +39,12 @@ export default function CategorySidebar() {
     fetchCategories();
   }, []);
 
+  useEffect(() => {
+    // Lấy categoryId từ query param nếu có
+    const catId = searchParams.get('filter')?.split(':')[2] || null;
+    setActiveCategory(catId);
+  }, [searchParams]);
+
   const handleMinPriceChange = (value) => {
     setMinPrice(value);
   };
@@ -43,6 +55,18 @@ export default function CategorySidebar() {
 
   const handleApplyPriceFilter = () => {
     // để xử lý
+  };
+
+  const handleCategoryClick = (categoryId) => {
+    const filterParam = `filter=categoryId:eq:${categoryId}`;
+    if (pathname.includes('/product')) {
+      // Nếu đang ở trang products, chỉ update query param
+      const url = `/product?page=0&size=10&${filterParam}`;
+      router.push(url);
+    } else {
+      // Nếu không phải trang products, redirect sang trang products với filter
+      router.push(`/product?page=0&size=10&${filterParam}`);
+    }
   };
 
   return (
@@ -57,17 +81,18 @@ export default function CategorySidebar() {
           overflowY: 'auto',
           padding: '0 16px',
         }}
+        selectedKeys={activeCategory ? [activeCategory] : []}
+        onClick={({ key }) => handleCategoryClick(key)}
         items={categories.map((category) => ({
           key: category.key,
           label: (
-            <a
-              href={category.path}
-              style={{ color: 'black' }}
+            <span
+              style={{ color: 'black', cursor: 'pointer', width: '100%', display: 'inline-block' }}
               onMouseEnter={e => (e.target.style.color = tokenCustomer.colorLinkHover)}
               onMouseLeave={e => (e.target.style.color = 'black')}
             >
               {category.label}
-            </a>
+            </span>
           ),
         }))}
       />

--- a/frontend/src/app/(customer)/components/header.jsx
+++ b/frontend/src/app/(customer)/components/header.jsx
@@ -6,16 +6,26 @@ import { ShoppingCartOutlined, UserOutlined, SearchOutlined } from '@ant-design/
 import { tokenCustomer } from '@/context/config_provider';
 import { useAppSelector } from '@/hooks/redux_hooks';
 import { T } from '@/app/common';
+import { useRouter, usePathname } from 'next/navigation';
 
 const { Header: AntHeader } = Layout;
 
 export default function Header({ isLoggedIn }) {
   const [searchQuery, setSearchQuery] = useState('');
   const user = useAppSelector('systemState', 'userReducer').user;
+  const router = useRouter();
+  const pathname = usePathname();
 
   const handleSearch = () => {
-    if (searchQuery.trim()) {
-      window.location.href = `/search?q=${encodeURIComponent(searchQuery)}`;
+    if (!searchQuery.trim()) return;
+    const searchParam = `search=${encodeURIComponent(searchQuery)}`;
+    if (pathname.includes('/product')) {
+      // Đang ở trang product, chỉ update query param để trigger API fetch
+      const url = `/product?page=0&size=10&${searchParam}`;
+      router.push(url);
+    } else {
+      // Không ở trang product, chuyển hướng sang product với search
+      router.push(`/product?page=0&size=10&${searchParam}`);
     }
   };
   const menuItems = user


### PR DESCRIPTION
These are two updates on this pull request
- integrate header search with BE
![image](https://github.com/user-attachments/assets/1e6c520e-fee6-4e97-9672-8135502ae5e6)

- integrate category filter with BE
- 
![image](https://github.com/user-attachments/assets/69186f2a-57ea-4c06-8ba2-43bead36ee9f)

NOTE: for now, the filter and the search cannot be applied at the same time, e.g. when applying the search, the filter will be reset and vice versa